### PR TITLE
Adding GH Action

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -15,6 +15,7 @@ jobs:
           project-url: ${{ secrets.GH_PROJECT_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT }}
   label_issues:
+    needs: add-to-project
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically add newly opened issues to a specific GitHub Project and label them. The workflow streamlines project management by automating these repetitive tasks.

### New GitHub Actions Workflow:

* `.github/workflows/add-to-project.yml`: Added a new workflow named "Add new issues to AI Tour GH Project." It triggers when issues are opened and performs the following actions:
  - Adds the newly opened issue to a GitHub Project using the `actions/add-to-project@v1.0.2` action.
  - Labels the issue with "ResourceCenter" by running a `gh issue edit` command.