### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -9,6 +9,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/aitour26-resource-center/security/code-scanning/1](https://github.com/microsoft/aitour26-resource-center/security/code-scanning/1)

To fix the problem, we should explicitly set the permissions for the `add-to-project` job to limit the access of the auto-generated `GITHUB_TOKEN`. As the only authentication used in this job is a custom secret (`secrets.ADD_TO_PROJECT`), the job does not require any permissions from the `GITHUB_TOKEN`. Therefore, adding `permissions: {}` to the job will follow the principle of least privilege and satisfy CodeQL’s recommendation.

Specifically:
- Edit `.github/workflows/add-to-project.yml`.
- Add a line `permissions: {}` in the `add-to-project` job, preferably after the `runs-on` key and before `steps` for clarity.
- No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
